### PR TITLE
Rename to universal-ctags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 The last *ctags* release on offer, 5.8, [dates from July 2009][1], and further development on the original repo would be surprising, to say the least. This repo makes [the most active, consistently updated fork of *ctags*][2] available as a tap in [Homebrew][3]. To use, do:
 
     brew tap kopischke/ctags
-    brew install ctags-fishman --HEAD
+    brew install universal-ctags --HEAD
 
 ## Caveat
 
-As the fishman fork has no version scheme, you **have** to use the `--HEAD` option when installing to get the fork – in Homebrew speak, the formula is “head only”. A plain `brew install ctags-fishman` will fail.
+As the fishman fork has no version scheme, you **have** to use the `--HEAD` option when installing to get the fork – in Homebrew speak, the formula is “head only”. A plain `brew install universal-ctags` will fail.
 
 [1]: http://ctags.sourceforge.net/
-[2]: https://github.com/fishman/ctags
+[2]: https://github.com/universal-ctags/ctags
 [3]: https://github.com/Homebrew/homebrew

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 The last *ctags* release on offer, 5.8, [dates from July 2009][1], and further development on the original repo would be surprising, to say the least. This repo makes [the most active, consistently updated fork of *ctags*][2] available as a tap in [Homebrew][3]. To use, do:
 
-    brew tap kopischke/ctags
-    brew install universal-ctags --HEAD
+    brew install kopischke/ctags/universal-ctags --HEAD
 
 ## Caveat
 

--- a/universal-ctags.rb
+++ b/universal-ctags.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
-class CtagsFishman < Formula
-  homepage 'https://github.com/fishman/ctags'
-  head 'https://github.com/fishman/ctags.git'
+class UniversalCtags < Formula
+  homepage 'https://github.com/universal-ctags/ctags'
+  head 'https://github.com/universal-ctags/ctags.git'
   depends_on :autoconf
   conflicts_with 'ctags', :because => 'this formula installs the same executable as the regular ctags.'
 


### PR DESCRIPTION
It looks like the fork got a proper name; it probably gets redirected by github now, but here's a PR with the proper name.
